### PR TITLE
docs: plan and API for AI Playground

### DIFF
--- a/docs/ia-playground/demo.md
+++ b/docs/ia-playground/demo.md
@@ -1,0 +1,12 @@
+# URL de démonstration
+
+L'application de démonstration est accessible après installation locale :
+
+```bash
+npm install
+npm run dev
+```
+
+Ouvrir ensuite <http://localhost:5173/ai-playground> dans le navigateur pour accéder à la page **AI Playground**.
+
+> La page fonctionne entièrement côté client dans cet environnement. Les appels IA et email sont simulés.

--- a/docs/ia-playground/design-system.md
+++ b/docs/ia-playground/design-system.md
@@ -1,0 +1,42 @@
+# Design system — AI Playground
+
+*Lien Figma* : <https://www.figma.com/file/placeholder/AI-Playground>
+
+## Couleurs principales
+| Nom | Valeur | Usage |
+|-----|--------|-------|
+| `primary` | `#0EA5E9` | Actions, liens, accent principal |
+| `secondary` | `#8B5CF6` | Survols, éléments interactifs |
+| `background` | `#0F172A` | Fond général (mode sombre) |
+| `surface` | `rgba(255,255,255,0.05)` | Cartes, panneaux (glassmorphism) |
+| `text-primary` | `#F8FAFC` | Titres et texte important |
+| `text-secondary` | `#CBD5E1` | Texte secondaire |
+
+## Typographie
+- Police principale : **Inter**, 16px de base
+- Titres : poids 600–700
+- Texte : poids 400–500
+
+## Rythme et composants
+- Grille 8px
+- Coins arrondis 16px
+- Ombres douces `0 4px 24px rgba(0,0,0,0.2)`
+
+### Composants clés
+- **Header** : titre, sous-titre, CTA primaire.
+- **Sélecteur de plateforme** : contrôle segmenté avec icônes (Instagram, LinkedIn, TikTok, X/Twitter, Facebook).
+- **Cartes d'idées** : surface translucide, animée au survol (scale 1.02).
+- **Éditeur** : onglets "Texte" et "Image", boutons régénérer.
+- **Prévisualisation** : mockups natifs de chaque réseau social.
+- **Cadres latéraux** : frames iPhone avec carrousel auto-scroll (pause on hover).
+
+## Mouvements & interactions
+- Transitions 200ms `ease-out`.
+- Parallaxe douce sur le fond (Framer Motion, `y` 20px).
+- Carrousel GPU (`translate3d`).
+- Focus visible `outline outline-2 outline-primary`.
+
+## Accessibilité
+- Contraste AA minimum 4.5:1.
+- Navigation clavier complète, `aria-label` sur les icônes.
+- Support des tailles de police système et `prefers-reduced-motion`.

--- a/docs/ia-playground/implementation-plan.md
+++ b/docs/ia-playground/implementation-plan.md
@@ -1,0 +1,38 @@
+# Plan de mise en œuvre — AI Playground
+
+## Jalons (3 semaines)
+
+### Semaine 1 – Design & préparation
+- Valider la direction artistique et les tokens dans Figma (couleurs, typo, composants).
+- Prototyper les écrans clés : sélection plateforme, idéation, éditeur, preview.
+- Définir les prompts et l'API contract (ce dépôt).
+- Installer la base technique (routes Next/Express, i18n, télémetrie).
+
+### Semaine 2 – Développement front & back
+- Implémenter l'interface responsive avec animations Framer Motion.
+- Intégrer la sélection plateforme et le flux idées -> contenu.
+- Brancher l'API OpenAI/OpenRouter et la génération d'images (Stable Diffusion / DALL·E).
+- Gérer l'OTP, les sessions et le cache 24h (Redis ou mémoire).
+
+### Semaine 3 – Finitions & QA
+- Ajouter micro-interactions, états d'erreur, accessibilité AA.
+- Optimiser performances (LCP <2.5s, CLS <0.1, bundle <200KB au-dessus de la ligne de flottaison).
+- Écrire les tests QA et automatiser lint/build.
+- Préparer démo publique et documentation finale.
+
+## Risques & atténuations
+- **Temps de génération élevé** : mettre en place streaming et cache ; surveiller la latence.
+- **Coûts IA** : tracer l'utilisation par plateforme, appliquer quotas.
+- **Complexité UI mobile** : prototyper tôt, tester sur appareils réels.
+- **Sécurité** : valider les entrées via Zod, stocker les clés côté serveur uniquement.
+
+## Dépendances
+- GPT-4o ou équivalent via OpenRouter.
+- Service d'images (Stable Diffusion / DALL·E + fallback stock).
+- Redis (cache & rate limit).
+
+## Livrables finaux
+- Code source front/back.
+- Figma mis à jour.
+- OpenAPI & prompts (docs/ia-playground).
+- URL de démo et guide de test.

--- a/docs/ia-playground/openapi.yaml
+++ b/docs/ia-playground/openapi.yaml
@@ -1,0 +1,253 @@
+openapi: 3.1.0
+info:
+  title: API AI Playground
+  version: '1.0.0'
+servers:
+  - url: /api
+paths:
+  /auth/signup:
+    post:
+      summary: Inscription et envoi d'OTP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignupRequest'
+      responses:
+        '200':
+          description: Inscription créée
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        '400':
+          $ref: '#/components/responses/ValidationError'
+  /auth/verify-otp:
+    post:
+      summary: Vérification du code OTP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyOtpRequest'
+      responses:
+        '200':
+          description: OTP valide
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  sid:
+                    type: string
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '423':
+          description: Session verrouillée
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /auth/session:
+    get:
+      summary: Statut de la session
+      responses:
+        '200':
+          description: État courant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+  /ia/ideas:
+    post:
+      summary: Génération de trois idées
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdeaRequest'
+      responses:
+        '200':
+          description: Idées générées
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdeaResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimit'
+  /ia/final:
+    post:
+      summary: Génération du contenu final
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FinalRequest'
+      responses:
+        '200':
+          description: Contenu final généré
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FinalResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimit'
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sid
+  schemas:
+    SignupRequest:
+      type: object
+      required: [name, email, sector, goal, consent]
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        company:
+          type: string
+        sector:
+          type: string
+        goal:
+          type: string
+        consent:
+          type: boolean
+    VerifyOtpRequest:
+      type: object
+      required: [email, code]
+      properties:
+        email:
+          type: string
+          format: email
+        code:
+          type: string
+    Session:
+      type: object
+      properties:
+        verified:
+          type: boolean
+        remainingGenerations:
+          type: integer
+    IdeaRequest:
+      type: object
+      required: [platform, brief]
+      properties:
+        platform:
+          type: string
+          enum: [linkedin, instagram, tiktok, twitter, facebook, image]
+        brief:
+          type: string
+        sector:
+          type: string
+        goal:
+          type: string
+    IdeaItem:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        angle:
+          type: string
+        value:
+          type: string
+        cta:
+          type: string
+    IdeaResponse:
+      type: object
+      properties:
+        ideas:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdeaItem'
+    FinalRequest:
+      type: object
+      required: [platform, choice, brief]
+      properties:
+        platform:
+          type: string
+          enum: [linkedin, instagram, tiktok, twitter, facebook, image]
+        choice:
+          type: string
+        brief:
+          type: string
+        sector:
+          type: string
+        goal:
+          type: string
+        tone:
+          type: string
+        cta:
+          type: string
+    FinalResponse:
+      type: object
+      properties:
+        content:
+          type: string
+        hashtags:
+          type: array
+          items:
+            type: string
+        caption:
+          type: string
+        image:
+          type: object
+          properties:
+            url:
+              type: string
+              format: uri
+            prompt:
+              type: string
+            ratio:
+              type: string
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+  responses:
+    ValidationError:
+      description: Erreur de validation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Non authentifié
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    RateLimit:
+      description: Limite atteinte
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/docs/ia-playground/prompt-templates.json
+++ b/docs/ia-playground/prompt-templates.json
@@ -1,0 +1,35 @@
+{
+  "system": {
+    "prompt": "Tu es Horizon, un assistant expert en copywriting social media et SEO. Respecte strictement les contraintes de la plateforme, propose 3 idées initiales concises puis un contenu final prêt à publier, structuré, clair, sans jargon inutile. Langue: identique à la requête. Ton: professionnel, engageant, adapté à l’audience. Si le brief est insuffisant, pose 3 questions ciblées avant de générer.",
+    "temperature": 0.3,
+    "language": "fr-FR"
+  },
+  "idea": {
+    "prompt": "Plateforme: {platform}\nProfession: {profession}\nAudience: {audience}\nObjectif: {goal}\nTon: {tone}\nConsignes: Propose exactement 3 idées de publications distinctes pour {platform}. Chaque idée doit inclure un titre accrocheur et une justification en une phrase.",
+    "temperature": 0.6,
+    "defaults": {
+      "tone": "professionnel et engageant",
+      "audience": "grand public",
+      "goal": "visibilité"
+    }
+  },
+  "content": {
+    "prompt": "Idée sélectionnée: {idea}\nPlateforme: {platform}\nProfession: {profession}\nTon: {tone}\nCTA: {cta}\nPolitiqueHashtags: {hashtagPolicy}\nLongueurMax: {length}\nGénère le contenu final optimisé pour {platform} avec structure adaptée (accroche, corps, CTA) et hashtags pertinents.",
+    "temperature": 0.4,
+    "defaults": {
+      "tone": "professionnel et engageant",
+      "cta": "Découvrir",
+      "hashtagPolicy": "5-10 hashtags pertinents",
+      "length": "auto"
+    }
+  },
+  "image": {
+    "prompt": "Contexte: {idea}\nProfession: {profession}\nPlateforme: {platform}\nCouleursDeMarque: {brandColors}\nStyle: {style}\nRatio: {ratio}\nGénère un prompt pour une image de haute qualité, esthétique futuriste, sans texte superflu, adaptée aux normes de {platform}.",
+    "temperature": 0.7,
+    "defaults": {
+      "brandColors": "#0ea5e9,#8b5cf6",
+      "style": "futuriste, minimal, glassmorphism",
+      "ratio": "1080x1080"
+    }
+  }
+}

--- a/docs/ia-playground/qa-tests.md
+++ b/docs/ia-playground/qa-tests.md
@@ -11,18 +11,27 @@ Cas IA
 - Idées: JSON invalide => fallback message
 - Final: succès
 - Timeout / 5xx OpenRouter => message utilisateur avec “Réessayer”
+- Cache 24h: même entrée => mêmes idées renvoyées instantanément
+- Image: génération échouée => fallback stock image
 
 UI/Accessibilité
 - Responsive <375px, 768px, 1024px, 1440px
 - Contraste AA (applitools/axe)
 - Navigation clavier dans le modal (focus trap, aria-modal)
 - Formulaire: erreurs champ par champ (email, consent obligatoire)
+- `prefers-reduced-motion`: animations désactivées
+- i18n: passage FR -> EN conserve l’état
 
 Quotas
 - Générer idées puis final = 1 crédit consommé
 - 3 crédits/ session => blocage UI, message clair
 
+Télémetrie
+- Événements envoyés: sélection plateforme, réussite/échec génération, abandon
+- Aucune donnée perso dans les logs
+
 Critères d’acceptation
 - Flux complet fonctionne (démo)
 - Erreurs FR claires, loaders visibles
 - Aucune clé API exposée côté client
+- Performance: latence idées <2.5s, final <5s


### PR DESCRIPTION
## Summary
- add design system spec and Figma link for AI Playground
- provide JSON prompt templates and OpenAPI contract
- document implementation plan, demo instructions, and expanded QA tests

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894928d5f8c8323826bd7daf65fbb52